### PR TITLE
Initial import and update of conda-forge feedstock.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,7 +6,11 @@ cd Build
 if errorlevel 1 exit 1
 
 :: Generate the build files.
-cmake .. -G"Ninja" %CMAKE_ARGS%
+cmake .. -G"Ninja" %CMAKE_ARGS% ^
+      -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DCMAKE_BUILD_TYPE=Release
+
 
 :: Build and install.
 ninja install

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,13 @@
-mkdir build
-cd build
+:: cmd
 
-cmake -G "NMake Makefiles" -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %CMAKE_ARGS% ..
+:: Isolate the build.
+mkdir Build
+cd Build
 if errorlevel 1 exit 1
 
-nmake install
+:: Generate the build files.
+cmake .. -G"Ninja" %CMAKE_ARGS%
+
+:: Build and install.
+ninja install
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,11 @@
-
 #!/bin/bash
 
-mkdir build
-cd build
+# Isolate the build.
+mkdir -p Build
+cd Build || exit 1
 
-cmake ${CMAKE_ARGS} -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=$PREFIX ..
-make install
+# Generate the build files.
+cmake .. -G"Ninja" ${CMAKE_ARGS}
+
+# Build and install.
+ninja install || exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,10 @@ mkdir -p Build
 cd Build || exit 1
 
 # Generate the build files.
-cmake .. -G"Ninja" ${CMAKE_ARGS}
+cmake .. -G"Ninja" ${CMAKE_ARGS} \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release
 
 # Build and install.
 ninja install || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,6 @@
 {% set version = "2.0.0" %}
+{% set hash = "4a73a77053822ca1ed6d4a2af416d31028ec992fb0ffa794af95bd6216bb6a20" %}
+{% set build_number = "0" %}
 
 package:
   name: termcolor-cpp
@@ -6,10 +8,10 @@ package:
 
 source:
   url: https://github.com/ikalnytskyi/termcolor/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 4a73a77053822ca1ed6d4a2af416d31028ec992fb0ffa794af95bd6216bb6a20
+  sha256: {{ hash }}
 
 build:
-  number: 0
+  number: {{ build_number }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,9 @@ build:
 
 requirements:
   build:
-    - cmake
     - {{ compiler('cxx') }}
-    - make  # [unix]
+    - cmake
+    - ninja
 
 test:
   commands:
@@ -27,8 +27,12 @@ test:
 about:
   home: https://github.com/ikalnytskyi/termcolor
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: 'Header-only C++ library for printing colored messages to the terminal.'
+  dev_url: https://github.com/ikalnytskyi/termcolor
+  doc_url: https://github.com/ikalnytskyi/termcolor#how-to-use
+  doc_src_url: https://github.com/ikalnytskyi/termcolor
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# Changes

Changes:
- Import from conda-forge.
- Simplify build scripts.
- Prefer ninja to make & nmake.
- Add dev and doc urls.

# Review Information

## Source

https://github.com/ikalnytskyi/termcolor/tree/v2.0.0

## Upstream Changes

Author doesn't seem to keep a changelog, but since we are not doing a
version update I think this is moot.

## Issues

https://github.com/ikalnytskyi/termcolor/issues

Nothin that matters. :-)

## Pins and Requireds

This is a header only C++ library that depends on system libraries
only. No pins reqired.


# Clossing Comments

Very simple library. No reason NOT to take it.